### PR TITLE
Escape path names in arguments

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -152,9 +152,9 @@ Process.prototype.start = function(fn){
   var self = this;
   var cmd = [this.mon];
   cmd.push('-d');
-  cmd.push('-l ' + this.logfile);
-  cmd.push('-p ' + this.pidfile);
-  cmd.push('-m ' + this.monpidfile);
+  cmd.push('-l "' + this.logfile + '"');
+  cmd.push('-p "' + this.pidfile + '"');
+  cmd.push('-m "' + this.monpidfile + '"');
 
   if (this.onerror) cmd.push('--on-error "' + this.onerror + ' ' + this.name + '"');
   if (this.onrestart) cmd.push('--on-restart "' + this.onrestart + ' ' + this.name + '"');


### PR DESCRIPTION
It totally slipped my mind that as of https://github.com/maxogden/monu/pull/8, anything being passed to mon with the config path in it needs to be escaped, since it'll have spaces. So... here we go! Now mongroup works with paths with spaces in it.
