### PR TITLE
Catch process.stop errors

### DIFF
--- a/lib/process.js
+++ b/lib/process.js
@@ -194,7 +194,11 @@ Process.prototype.pollExit = function(fn){
   setTimeout(function(){
     if (self.monalive()) return self.pollExit(fn);
     debug('poll %s for exit', self.name);
-    self.removePidfiles();
+    try {
+      self.removePidfiles();
+    } catch (err) {
+      return fn(err);
+    }
     fn();
   }, 500);
 };


### PR DESCRIPTION
Here's a fix to the issue https://github.com/tj/node-mongroup/issues/13 to properly handle process.stop errors.
I'd create a new branch in your project (or merge into master, so the existing pr would stay clean), but I don't have the permission to do that.
It would be nice if we can merge this stuff into the original repo from @tj. Maybe we can convince @tj to become contributors :wink: 
